### PR TITLE
fix build with meson 1.8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.ignore/
+.venv/
+.vscode/
+subprojects/FFmpeg/
+builddir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN cp ./scripts/ffmpeg_android.meson.build ./subprojects/FFmpeg/meson.build
 RUN cp -r ${ROOT_DIR}/ffmpeg-android-maker/output/lib/arm64-v8a/* ./subprojects/FFmpeg/arm64-v8a/lib
 RUN cp -r ${ROOT_DIR}/ffmpeg-android-maker/output/include/arm64-v8a/* ./subprojects/FFmpeg/arm64-v8a/include
 
-RUN meson setup --wipe -Ddebug=true -Dlibmaf=true -Dcsharp=true -Davpipeline=true ./builddir/android-aarch64 --cross-file ./crossfile/android-aarch64-docker
+RUN meson setup --wipe -Ddebug=true ./builddir/android-aarch64 --cross-file ./crossfile/android-aarch64-docker
 RUN meson compile -C ./builddir/android-aarch64
 
 ## @TODO: SWIG bindings

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y --no-install
 RUN python3 -m venv /root/venv
 ENV VIRTUAL_ENV /root/venv
 ENV PATH /root/venv/bin:$PATH
-RUN python3 -m pip install meson ninja
+RUN python3 -m pip install meson==1.8.0 ninja
 
 # Install Android SDK
 RUN curl https://dl.google.com/android/repository/commandlinetools-linux-${VERSION_SDK}_latest.zip --output ${ROOT_DIR}/android-sdk.zip

--- a/subprojects/maf/meson.build
+++ b/subprojects/maf/meson.build
@@ -21,7 +21,6 @@ libmaf = both_libraries(
     include_directories : libmaf_includes,
     gnu_symbol_visibility : 'default',
     pic : true,
-    install : get_option('libmaf'),
     install_tag: 'libmaf'
 )
 


### PR DESCRIPTION
Accessing global option in subproject seems no longer supported with the most recent meson 1.8. The option was actually no longer relevant. 